### PR TITLE
Fix build on Linux/X11

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,8 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.11.1"}
-  io.github.humbleui/humbleui {:git/sha "33fb03efc8feb10cfaf4d0e4326fb002d0f81ebb"}
+  io.github.humbleui/humbleui {:git/sha "97f11aab13765bc747c0cabfde49ebbec5ea74ea"}}
  :aliases
  {:dev {:extra-paths ["dev"]
         :extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
                      org.clojure/tools.namespace {:mvn/version "1.3.0"}}
         :jvm-opts ["-ea"]}}}
- 

--- a/script/nrepl.sh
+++ b/script/nrepl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 cd "$(dirname "$0")/.."
 

--- a/script/run.sh
+++ b/script/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 cd "$(dirname "$0")/.."
 

--- a/src/humble_deck/controls.clj
+++ b/src/humble_deck/controls.clj
@@ -109,7 +109,7 @@
   protocols/IComponent
   (-measure [_ ctx cs]
     (let [{:keys [scale]} ctx]
-      (core/size (* scale thumb-w) (* scale thumb-h))))
+      (core/isize (* scale thumb-w) (* scale thumb-h))))
 
   (-draw [this ctx rect ^Canvas canvas]
     (let [{:keys [scale]} ctx

--- a/src/humble_deck/main.clj
+++ b/src/humble_deck/main.clj
@@ -36,12 +36,15 @@
 
 (defn -main [& _args]
   (ui/start-app!
-    (deliver state/*window
-      (ui/window
-        {:title    "Humble Deck"
-         :mac-icon "resources/icon.icns"
-         :bg-color 0xFFFFFFFF}
-        state/*app)))
+   (deliver state/*window
+            (ui/window
+             {:title    "Humble Deck"
+              :mac-icon "resources/icon.icns"
+              :bg-color 0xFFFFFFFF}
+             state/*app)))
+  ;; NOTE:
+  ;; Should assess whether we can use Metal or GL here.
+  ;; Might be having platform compatibility issues.
   (set! (.-_colorSpace ^LayerGLSkija (.getLayer ^Window @state/*window)) (ColorSpace/getDisplayP3))
-  ; (reset! debug/*enabled? true)
+                                        ; (reset! debug/*enabled? true)
   (common/redraw))

--- a/src/humble_deck/main.clj
+++ b/src/humble_deck/main.clj
@@ -11,7 +11,7 @@
   (:import
     [io.github.humbleui.skija ColorSpace]
     [io.github.humbleui.jwm Window]
-    [io.github.humbleui.jwm.skija LayerMetalSkija]))
+    [io.github.humbleui.jwm.skija LayerMetalSkija LayerGLSkija]))
 
 (def app
   (common/with-context
@@ -42,6 +42,6 @@
          :mac-icon "resources/icon.icns"
          :bg-color 0xFFFFFFFF}
         state/*app)))
-  (set! (.-_colorSpace ^LayerMetalSkija (.getLayer ^Window @state/*window)) (ColorSpace/getDisplayP3))
+  (set! (.-_colorSpace ^LayerGLSkija (.getLayer ^Window @state/*window)) (ColorSpace/getDisplayP3))
   ; (reset! debug/*enabled? true)
   (common/redraw))

--- a/src/humble_deck/speaker.clj
+++ b/src/humble_deck/speaker.clj
@@ -134,22 +134,29 @@
 (def speaker-app
   (controls/key-listener
     (ui/event-listener
-      {:window-close-request
-       (fn [_]
-         (reset! state/*speaker-window nil))
-       :key
-       (fn [{:keys [pressed? modifiers key]}]
-         (when (and 
-                 pressed?
-                 (modifiers :mac-command)
-                 (= :w key))
-           (common/speaker-close!)))}
-      (common/with-context {:fill-text (paint/fill 0xFFFFFFFF)}
-        (ui/column
-          [:stretch 1 time]
-          slides
-          [:stretch 1
-           (ui/valign 1
-             (ui/column
-               progress-controls
-               controls/controls-impl))])))))
+     EventWindowCloseRequest
+     :key
+     (fn [e ctx]
+       (when (and
+              (:pressed? e)
+              (modifiers :mac-command)
+              (= :w (:key e)))
+         (common/speaker-close!)))
+
+     ;; {:window-close-request
+     ;;  (fn [_]
+     ;;    (reset! state/*speaker-window nil))
+     ;;  :key
+     (fn [{:keys [pressed? modifiers key]}]
+       )
+
+
+     (common/with-context {:fill-text (paint/fill 0xFFFFFFFF)}
+       (ui/column
+        [:stretch 1 time]
+        slides
+        [:stretch 1
+         (ui/valign 1
+                    (ui/column
+                     progress-controls
+                     controls/controls-impl))])))))

--- a/src/humble_deck/speaker.clj
+++ b/src/humble_deck/speaker.clj
@@ -134,12 +134,12 @@
 (def speaker-app
   (controls/key-listener
     (ui/event-listener
-     EventWindowCloseRequest
+     {:capture? true}
      :key
      (fn [e ctx]
        (when (and
               (:pressed? e)
-              (modifiers :mac-command)
+              ((:modifiers e) :mac-command)
               (= :w (:key e)))
          (common/speaker-close!)))
 
@@ -147,8 +147,8 @@
      ;;  (fn [_]
      ;;    (reset! state/*speaker-window nil))
      ;;  :key
-     (fn [{:keys [pressed? modifiers key]}]
-       )
+     ;; (fn [{:keys [pressed? modifiers key]}]
+     ;;   )
 
 
      (common/with-context {:fill-text (paint/fill 0xFFFFFFFF)}


### PR DESCRIPTION
- Support GL backend in addition to Metal
- Fix `deps.edn` file (it's missing a closing brace)
- Bump HumbleUI version

[ ] Integrate https://github.com/HumbleUI/JWM/issues/130
[ ] Sort out `95 < 92` error runtime error message on mouse move