### PR TITLE
Fix shell script exec paths

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,9 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.11.1"}
-  io.github.humbleui/humbleui {:git/sha "33fb03efc8feb10cfaf4d0e4326fb002d0f81ebb"}
+  io.github.humbleui/humbleui {:git/sha "5bf5e2a47bf99818c6e7f712c43462d4ecb6254c"
+                               #_#_:local/root "/Users/tonsky/ws/humbleui"}}
  :aliases
  {:dev {:extra-paths ["dev"]
         :extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
                      org.clojure/tools.namespace {:mvn/version "1.3.0"}}
         :jvm-opts ["-ea"]}}}
- 

--- a/script/nrepl.sh
+++ b/script/nrepl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 cd "$(dirname "$0")/.."
 

--- a/script/run.sh
+++ b/script/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
Some Linux systems don't place all executables in `/bin/` (like mine). This makes the scripts runnable on more Unix systems.